### PR TITLE
Fix composer plugin api requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
         "class": "hhvm\\DebianInstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "^1.0.0"
     }
 }


### PR DESCRIPTION
Without this patch if we bump the composer plugin API to 1.1+ your plugin won't be installable anymore.

Also note that I transfered the package ownership to @fredemmott on packagist as it was owned by the hhvm account which points to an email that bounces (keith miller left FB I guess). That hhvm account is now kinda dead and has no ownership left.
